### PR TITLE
googleCS.js : Removes the "Index of " portion from the search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chrome-search-extension
+# Fearch
 
 A chrome extension that lets you search music, videos, ebooks and other content available on FTP servers. It uses simple google search under the hood with the query modified to look only for FTP servers. We are interested in the content that is freely available on these servers.
 

--- a/googleCS.js
+++ b/googleCS.js
@@ -1,6 +1,21 @@
+var st;
+var x;
+var i;
+var pos;
+
 var s = document.createElement("script");
 s.src = chrome.extension.getURL("googleFearch.js");
 (document.head || document.documentElement).appendChild(s);
+
+// removing the leading Indeex of part from search results
+x = document.document.getElementsByClassName("r");
+for (i = 0; i < x.length; i += 1) {
+    st = x[i].innerHTML;
+    pos = st.search("Index of /" || "Index of");
+    if (pos !== -1) {
+        x[i].innerHTML = st.replace(st.substring(pos, pos + 10), "");
+    }
+}
 
 // After loading and execution, the node disappears so no one can trace code.
 s.onload = function () {


### PR DESCRIPTION
Remove the leading " Index of" or "Index of /" part from the google search result to make the search results more meaningful .

fix #45 