### PR TITLE
Remove the leading Index of part from google search result

### DIFF
--- a/googleCS.js
+++ b/googleCS.js
@@ -1,8 +1,22 @@
+var st;
+var pos;
+var i;
+var x;
 var s = document.createElement("script");
 s.src = chrome.extension.getURL("googleFearch.js");
 (document.head || document.documentElement).appendChild(s);
 
+// removing the leading "Index of" portion from the search result
+x = document.getElementsByClassName("r");
+for (i = 0; i < x.length; i += 1) {
+    st = x[i].innerHTML;
+    pos = st.search("Index of /" || "Index of");
+    if (pos !== -1) {
+        x[i].innerHTML = st.replace(st.substring(pos, pos + 10), "");
+    }
+}
 // After loading and execution, the node disappears so no one can trace code.
+
 s.onload = function () {
     s.parentNode.removeChild(s);
 };


### PR DESCRIPTION
Remove the leading "Index of" or "Index of /" portion from google search results.

Fix #45 