### PR TITLE
popup.js:Added keyboard shortcut for selecting category

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -42,11 +42,11 @@
                 <tr>
                     <td colspan="2">
                         <input type="checkbox" name="music" value="music" id="music">
-                        <label for="music">Music</label>
+                        <label for="music" title="Ctrl+Alt+m">Music</label>
                         <input type="checkbox" name="video" value="video" id="video">
-                        <label for="video">Video</label>
+                        <label for="video" title="Ctrl+Alt+v">Video</label>
                         <input type="checkbox" name="books" value="books" id="books">
-                        <label for="books">Books</label>
+                        <label for="books" title="Ctrl+Alt+b">Books</label>
                     </td>
                 </tr>
                 <tr>

--- a/popup.js
+++ b/popup.js
@@ -10,6 +10,40 @@ function suggestionAsValue() {
     });
 }
 
+// Method to keyboard shortcut
+function keyboardShortCutListener(e) {
+	e.preventDefault();
+	if (e.ctrlKey && e.altKey && e.keyCode === 77) {
+		if (document.getElementById("music").checked === true) {
+			document.getElementById("music").checked = false;
+		} else {
+            document.getElementById("music").checked = true;
+		}
+	}  else if (e.ctrlKey && e.altKey && e.keyCode === 86) {
+		if (document.getElementById("video").checked === true) {
+			document.getElementById("video").checked = false;
+		} else {
+			document.getElementById("video").checked = true;
+		}
+	}  else if (e.ctrlKey && e.altKey && e.keyCode === 66) {
+		if (document.getElementById("books").checked === true) {
+			document.getElementById("books").checked = false;
+		} else {
+			document.getElementById("books").checked = true;
+		}
+	}  else if (e.ctrlKey && e.altKey && e.keyCode === 65) {
+        if ((document.getElementById("music").checked === true) && (document.getElementById("video").checked === true) && (document.getElementById("books").checked === true)) {
+            document.getElementById("music").checked = false;
+            document.getElementById("video").checked = false;
+            document.getElementById("books").checked = false;
+        } else {
+            document.getElementById("music").checked = true;
+            document.getElementById("video").checked = true;
+            document.getElementById("books").checked = true;
+        }
+	}
+}
+
 function register(event) {
     var set1;
     var set2;
@@ -108,6 +142,7 @@ function suggestion() {
 
 document.addEventListener("DOMContentLoaded", function () {
     document.querySelector("button").addEventListener("click", register);
+    document.addEventListener('keyup', keyboardShortCutListener, false);
     suggestion();
     suggestionAsValue();
 });


### PR DESCRIPTION
pupup.html:Added title for displaying tooltip text showing keyboard shorcut for categories

Now the category checkboxes can be selected using following keyboard shortcuts :
Ctrl+Alt+m : toggle music
Ctrl+Alt+v : toggle video
Ctrl+Alt+b : toggle books
Ctrl+Alt+a : select all the categories
Hovering mouse over the category labels displays tooltip text showing the key combination
for the respective category.
The tooltip text is presently shown only in chrome and not in firefox because of
a bug (bugzilla id : 1269421) which has been fixed and the feature will be available
from firefox 52 (which is in development version now)

fixes #88